### PR TITLE
Use only self.add_cmd_output in plugin

### DIFF
--- a/iml_sos_plugin/iml.py
+++ b/iml_sos_plugin/iml.py
@@ -13,7 +13,7 @@ class IML(Plugin, RedHatPlugin):
     """
 
     plugin_name = "iml"
-    profiles = ('lustre',)
+    profiles = ("lustre",)
     requires_root = True
 
     def setup(self):
@@ -36,27 +36,32 @@ class IML(Plugin, RedHatPlugin):
 
         self.add_copy_spec(copy_globs, sizelimit=limit, tailit=tailit)
 
-        self.add_cmd_output([
-            'chroma-agent device_plugin --plugin=linux',
-            'chroma-agent detect_scan',
-            'chroma-config validate',
-            'chroma-agent device_plugin --plugin=linux_network',
-            'lctl device_list',
-            'lctl debug_kernel',
-            'lctl list_nids',
-            'blkid -s UUID -s TYPE',
-            'df --all',
-            'ps -ef --forest',
-            'cibadmin --query',
-        ])
+        self.add_cmd_output(
+            [
+                "chroma-agent device_plugin --plugin=linux",
+                "chroma-agent detect_scan",
+                "chroma-config validate",
+                "chroma-agent device_plugin --plugin=linux_network",
+                "lctl device_list",
+                "lctl debug_kernel",
+                "lctl list_nids",
+                "blkid -s UUID -s TYPE",
+                "df --all",
+                "ps -ef --forest",
+                "cibadmin --query",
+            ]
+        )
 
         time_stamp = datetime.now().strftime("%Y%m%dT%H%M%S")
-        db_file_name = 'chromadb_%s.sql.gz' % time_stamp
+        db_file_name = "chromadb_%s.sql.gz" % time_stamp
         db_dest = path.join(self.get_cmd_output_path(), db_file_name)
 
-        self.get_command_output(
-            'pg_dump -U chroma -F p -Z 9 -w -f %s -T chroma_core_logmessage* -T'
-            ' chroma_core_series* -T chroma_core_sample_* chroma' % db_dest
+        cmd = (
+            "pg_dump -U chroma -F p -Z 9 -w -f %s -T chroma_core_logmessage* -T chroma_core_series* -T chroma_core_sample_* chroma"
+            % db_dest
         )
+
+        self.add_cmd_output(cmd, chroot=self.tmp_in_sysroot())
+
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
This is required for newer (3.7?) versions of sos.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>